### PR TITLE
Support datetime and UUID attributes

### DIFF
--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -35,6 +35,7 @@ def store_pub_sub_event_in_bigquery(cloud_event):
     }
 
     row = {
+        "uuid": attributes.pop("uuid"),
         "event": event,
         "other_attributes": attributes,
         # Pull out some attributes into columns for querying.

--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -30,11 +30,11 @@ def store_pub_sub_event_in_bigquery(cloud_event):
 
     backend_metadata = {
         "message_id": cloud_event.data["message"]["messageId"],
-        "publish_time": cloud_event.data["message"]["publishTime"],
         "ordering_key": cloud_event.data["message"].get("orderingKey"),
     }
 
     row = {
+        "datetime": attributes.pop("datetime"),
         "uuid": attributes.pop("uuid"),
         "event": event,
         "other_attributes": attributes,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="twined-gcp",
-    version="0.3.1",
+    version="0.4.0",
     author="Marcus Lugg <marcus@octue.com>",
     install_requires=[
         "setuptools",

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -26,6 +26,7 @@ class TestEventHandler(unittest.TestCase):
                         "recipient": "octue/another-service:1.0.0",
                         "question_uuid": "ca534cdd-24cb-4ed2-af57-e36757192acb",
                         "order": "0",
+                        "forward_logs": True,
                     },
                     "messageId": "1234",
                     "publishTime": "some-datetime",
@@ -41,9 +42,10 @@ class TestEventHandler(unittest.TestCase):
         self.assertEqual(
             mock_big_query_client.inserted_rows[0][0],
             {
+                "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
                 "event": {"some": "data"},
                 "other_attributes": {
-                    "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
+                    "forward_logs": True,
                 },
                 "originator": "octue/test-service:5.6.3",
                 "sender": "octue/test-service:5.6.3",

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -18,6 +18,7 @@ class TestEventHandler(unittest.TestCase):
                 "message": {
                     "data": base64.b64encode(b'{"some": "data"}'),
                     "attributes": {
+                        "datetime": "2024-04-11T09:26:39.144818",
                         "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
                         "originator": "octue/test-service:5.6.3",
                         "sender": "octue/test-service:5.6.3",
@@ -29,7 +30,6 @@ class TestEventHandler(unittest.TestCase):
                         "forward_logs": True,
                     },
                     "messageId": "1234",
-                    "publishTime": "some-datetime",
                 }
             }
         )
@@ -42,6 +42,7 @@ class TestEventHandler(unittest.TestCase):
         self.assertEqual(
             mock_big_query_client.inserted_rows[0][0],
             {
+                "datetime": "2024-04-11T09:26:39.144818",
                 "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
                 "event": {"some": "data"},
                 "other_attributes": {
@@ -55,6 +56,6 @@ class TestEventHandler(unittest.TestCase):
                 "question_uuid": "ca534cdd-24cb-4ed2-af57-e36757192acb",
                 "order": "0",
                 "backend": "GoogleCloudPubSub",
-                "backend_metadata": {"message_id": "1234", "publish_time": "some-datetime", "ordering_key": None},
+                "backend_metadata": {"message_id": "1234", "ordering_key": None},
             },
         )


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#7](https://github.com/octue/twined-gcp/pull/7))

**IMPORTANT:** There are 2 breaking changes.

### Enhancements
- 💥 **BREAKING CHANGE:** Store event UUID in its own column
- 💥 **BREAKING CHANGE:** Replace Pub/Sub publish time with backend-agnostic `datetime` attribute

---
# Upgrade instructions
Add to your bigquery table:
- A `datetime` column of the `TIMESTAMP` type
- A `uuid` column of the `STRING` type

<!--- END AUTOGENERATED NOTES --->