### PR TITLE
Store event kind in a separate column

### DIFF
--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -36,6 +36,7 @@ def store_pub_sub_event_in_bigquery(cloud_event):
     row = {
         "datetime": attributes.pop("datetime"),
         "uuid": attributes.pop("uuid"),
+        "kind": event.pop("kind"),
         "event": event,
         "other_attributes": attributes,
         # Pull out some attributes into columns for querying.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="twined-gcp",
-    version="0.4.0",
+    version="0.5.0",
     author="Marcus Lugg <marcus@octue.com>",
     install_requires=[
         "setuptools",

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -16,7 +16,7 @@ class TestEventHandler(unittest.TestCase):
         cloud_event = MockCloudEvent(
             data={
                 "message": {
-                    "data": base64.b64encode(b'{"some": "data"}'),
+                    "data": base64.b64encode(b'{"kind": "heart", "some": "data"}'),
                     "attributes": {
                         "datetime": "2024-04-11T09:26:39.144818",
                         "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
@@ -44,6 +44,7 @@ class TestEventHandler(unittest.TestCase):
             {
                 "datetime": "2024-04-11T09:26:39.144818",
                 "uuid": "c8bda9fa-f072-4330-92b1-96920d06b28d",
+                "kind": "heart",
                 "event": {"some": "data"},
                 "other_attributes": {
                     "forward_logs": True,


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#9](https://github.com/octue/twined-gcp/pull/9))

**IMPORTANT:** There is 1 breaking change.

### Enhancements
- 💥 **BREAKING CHANGE:** Store event kind in a separate column

---
# Upgrade instructions
<details>
<summary>💥 <b>Store event kind in a separate column</b></summary>

Add a `kind` column to the BigQuery table the event handler feeds and migrate the "kind" key/value out of the `event` column into it.
</details>

<!--- END AUTOGENERATED NOTES --->