### PR TITLE
Remove backoff limit from Kueue pods

### DIFF
--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -163,9 +163,6 @@ def _dispatch_question_as_kueue_job(event, attributes, batch_api):
             # Jobs must be suspended at creation for Kueue to manage them.
             suspend=True,
             template=job_template,
-            # Setting a backoff limit of 1 (in combination with a pod restart policy of "never") means we can cancel a
-            # question by deleting its pod.
-            backoff_limit=1,
         ),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twined-gcp"
-version = "0.7.1"
+version = "0.7.2"
 description = ""
 authors = [
     {name = "Marcus Lugg", email = "marcus@octue.com"}


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#15](https://github.com/octue/twined-gcp/pull/15))

### Fixes
- Remove backoff limit of 1 from Kueue pods

<!--- END AUTOGENERATED NOTES --->