### PR TITLE
Update for new Twined version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ of this for you.
 | Name                                 | Description                                                                                                                                               |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BIGQUERY_EVENTS_TABLE`              | The full ID of the BigQuery table to store events in in `<dataset-name>.<table-name>` format                                                              |
-| `OCTUE_SERVICES_TOPIC_NAME`          | The name of the Pub/Sub topic that events are published to in this Octue Twined service network.                                                          |
+| `TWINED_SERVICES_TOPIC_NAME`         | The name of the Pub/Sub topic that events are published to in this Octue Twined service network.                                                          |
 | `KUBERNETES_SERVICE_ACCOUNT_NAME`    | The name of the Kubernetes service account to assign to the Kueue jobs                                                                                    |
 | `KUBERNETES_CLUSTER_ID`              | The ID of the Kubernetes cluster in `projects/<project-id>/locations/<region>/clusters/<cluster-name>` format                                             |
 | `KUEUE_LOCAL_QUEUE`                  | The name of the local queue that jobs are dispatched to by Kueue                                                                                          |

--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -133,7 +133,7 @@ def _dispatch_question_as_kueue_job(event, attributes, batch_api):
                 kubernetes.client.V1Container(
                     image=artifact_registry_repository_url + "/" + attributes["recipient"],
                     name=job_name,
-                    command=["octue", "question", "ask", "local"],
+                    command=["octue", "twined", "question", "ask", "local"],
                     args=job_args,
                     resources=resources,
                     env=[

--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -99,7 +99,7 @@ def _dispatch_question_as_kueue_job(event, attributes, batch_api):
     :param kubernetes.client.BatchV1Api batch_api: the kubernetes batch API
     :return None:
     """
-    octue_services_topic_name = os.environ["OCTUE_SERVICES_TOPIC_NAME"]
+    twined_services_topic_name = os.environ["TWINED_SERVICES_TOPIC_NAME"]
     kubernetes_service_account_name = os.environ["KUBERNETES_SERVICE_ACCOUNT_NAME"]
     kueue_local_queue = os.environ["KUEUE_LOCAL_QUEUE"]
     artifact_registry_repository_url = os.environ["ARTIFACT_REGISTRY_REPOSITORY_URL"]
@@ -137,7 +137,7 @@ def _dispatch_question_as_kueue_job(event, attributes, batch_api):
                     args=job_args,
                     resources=resources,
                     env=[
-                        kubernetes.client.V1EnvVar(name="OCTUE_SERVICES_TOPIC_NAME", value=octue_services_topic_name),
+                        kubernetes.client.V1EnvVar(name="TWINED_SERVICES_TOPIC_NAME", value=twined_services_topic_name),
                         kubernetes.client.V1EnvVar(name="COMPUTE_PROVIDER", value=COMPUTE_PROVIDER),
                         kubernetes.client.V1EnvVar(name="OCTUE_SERVICE_REVISION_TAG", value=service_revision_tag),
                     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twined-gcp"
-version = "0.7.2"
+version = "0.8.0"
 description = ""
 authors = [
     {name = "Marcus Lugg", email = "marcus@octue.com"}

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -167,7 +167,7 @@ class TestEventHandler(unittest.TestCase):
         container = job.spec.template["spec"]["containers"][0]
         self.assertEqual(container.name, job.metadata.name)
         self.assertEqual(container.image, f"some-artifact-registry-url/{SRUID}")
-        self.assertEqual(container.command, ["octue", "question", "ask", "local"])
+        self.assertEqual(container.command, ["octue", "twined", "question", "ask", "local"])
 
         # Check the default resource requirements are used.
         self.assertEqual(container.resources, {"requests": {"cpu": 1, "ephemeral-storage": "1Gi", "memory": "500Mi"}})

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -40,7 +40,7 @@ class TestEventHandler(unittest.TestCase):
             "os.environ",
             {
                 "BIGQUERY_EVENTS_TABLE": "my-table",
-                "OCTUE_SERVICES_TOPIC_NAME": "test.octue.services",
+                "TWINED_SERVICES_TOPIC_NAME": "test.octue.services",
                 "KUEUE_LOCAL_QUEUE": "test-queue",
                 "ARTIFACT_REGISTRY_REPOSITORY_URL": "some-artifact-registry-url",
                 "KUBERNETES_SERVICE_ACCOUNT_NAME": "kubernetes-sa",
@@ -182,7 +182,7 @@ class TestEventHandler(unittest.TestCase):
         self.assertEqual(
             environment_variables,
             [
-                {"name": "OCTUE_SERVICES_TOPIC_NAME", "value": "test.octue.services", "value_from": None},
+                {"name": "TWINED_SERVICES_TOPIC_NAME", "value": "test.octue.services", "value_from": None},
                 {"name": "COMPUTE_PROVIDER", "value": "GOOGLE_KUEUE", "value_from": None},
                 {"name": "OCTUE_SERVICE_REVISION_TAG", "value": "1.0.0", "value_from": None},
             ],


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#20](https://github.com/octue/twined-gcp/pull/20))

**IMPORTANT:** There is 1 breaking change.

### Enhancements
- 💥 **BREAKING CHANGE:** Use new Twined CLI
- Update topic name envvar to `TWINED_SERVICES_TOPIC_NAME`

---
# Upgrade instructions
<details>
<summary>💥 <b>Use new Twined CLI</b></summary>

Use with Twined services running `octue>=0.67.0`
</details>

<!--- END AUTOGENERATED NOTES --->