### PR TITLE
Add new container command to event handler

### DIFF
--- a/functions/event_handler/main.py
+++ b/functions/event_handler/main.py
@@ -133,6 +133,7 @@ def _dispatch_question_as_kueue_job(event, attributes, batch_api):
                 kubernetes.client.V1Container(
                     image=artifact_registry_repository_url + "/" + attributes["recipient"],
                     name=job_name,
+                    command=["octue", "twined", "question", "ask-local"],
                     args=job_args,
                     resources=resources,
                     env=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twined-gcp"
-version = "0.9.0"
+version = "0.9.1"
 description = ""
 authors = [
     {name = "Marcus Lugg", email = "marcus@octue.com"}

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -167,6 +167,7 @@ class TestEventHandler(unittest.TestCase):
         container = job.spec.template["spec"]["containers"][0]
         self.assertEqual(container.name, job.metadata.name)
         self.assertEqual(container.image, f"some-artifact-registry-url/{SRUID}")
+        self.assertEqual(container.command, ["octue", "twined", "question", "ask-local"])
 
         # Check the default resource requirements are used.
         self.assertEqual(container.resources, {"requests": {"cpu": 1, "ephemeral-storage": "1Gi", "memory": "500Mi"}})


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#25](https://github.com/octue/twined-gcp/pull/25))

**IMPORTANT:** There is 1 breaking change.

### Fixes
- Use new `octue` CLI command as service container entrypoint

<!--- END AUTOGENERATED NOTES --->

---
# Upgrade instructions
<details>
<summary>💥 <b>Use new `octue` CLI command as service container entrypoint</b></summary>

All Twined services using this version of the evet handler must be using `octue>=0.69.0`.
</details>